### PR TITLE
Change test namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Tests\\": "tests/"
+            "Brayniverse\\LaravelRouteViewHelper\\Tests\\": "tests/"
         }
     },
     "scripts": {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests;
+namespace Brayniverse\LaravelRouteViewHelper\Tests;
 
 class TestCase extends \Orchestra\Testbench\TestCase
 {

--- a/tests/ViewControllerTest.php
+++ b/tests/ViewControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests;
+namespace Brayniverse\LaravelRouteViewHelper\Tests;
 
 use Illuminate\Support\Facades\Route;
 


### PR DESCRIPTION
Using the `Tests` namespace confuses some IDEs so I'm changing the namespace to `Brayniverse\LaravelRouteviewHelper\Tests`.

_Namespaced tests are overkill for such a small test-suite, I may remove them later._