### PR TITLE
Remove test namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,11 +31,6 @@
             "Brayniverse\\LaravelRouteViewHelper\\": "src/"
         }
     },
-    "autoload-dev": {
-        "psr-4": {
-            "Brayniverse\\LaravelRouteViewHelper\\Tests\\": "tests/"
-        }
-    },
     "scripts": {
         "test": "vendor/bin/phpunit tests"
     }

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,11 @@
             "Brayniverse\\LaravelRouteViewHelper\\": "src/"
         }
     },
+    "autoload-dev": {
+        "classmap": [
+            "tests/TestCase.php"
+        ]
+    },
     "scripts": {
         "test": "vendor/bin/phpunit tests"
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Brayniverse\LaravelRouteViewHelper\Tests;
-
 class TestCase extends \Orchestra\Testbench\TestCase
 {
     protected function getPackageProviders($app)

--- a/tests/ViewControllerTest.php
+++ b/tests/ViewControllerTest.php
@@ -1,9 +1,5 @@
 <?php
 
-namespace Brayniverse\LaravelRouteViewHelper\Tests;
-
-use Illuminate\Support\Facades\Route;
-
 class ViewControllerTest extends TestCase
 {
     public function test_view_rendered()


### PR DESCRIPTION
Namespaced tests are overkill for such a small test-suite; going to remove namespaces to prevent IDEs getting confused.